### PR TITLE
Automatically execute setup

### DIFF
--- a/Assert.js
+++ b/Assert.js
@@ -36,7 +36,7 @@ class Assert {
             }
         }
 
-        if (!A.isSetup) {
+        if (!A.hasOwnProperty('isSetup')) {
             A.setup();
         }
     }
@@ -578,7 +578,7 @@ class Assert {
         const A = this;
 
         // ensure the defaults are setup first
-        if (!A.isSetup) {
+        if (!A.hasOwnProperty('isSetup')) {
             A.setup();
         }
 

--- a/Assert.js
+++ b/Assert.js
@@ -36,7 +36,7 @@ class Assert {
             }
         }
 
-        if (!A.hasOwnProperty('registry')) {
+        if (!A.isSetup) {
             A.setup();
         }
     }
@@ -577,6 +577,11 @@ class Assert {
     static register (...args) {
         const A = this;
 
+        // ensure the defaults are setup first
+        if (!A.isSetup) {
+            A.setup();
+        }
+
         for (let registry of args) {
             if (typeof registry === 'function') {
                 registry.call(A, A, Util);
@@ -644,6 +649,8 @@ class Assert {
 
     static setup () {
         let registry = this.getDefaults();
+
+        this.isSetup = true;
 
         this.register(registry);
     }

--- a/test/specs/Assert.js
+++ b/test/specs/Assert.js
@@ -2823,8 +2823,6 @@ describe('Custom Assert', function () {
 
     const expect = CustomAssert.expect.bind(CustomAssert);
 
-    CustomAssert.setup();
-
     CustomAssert.register({
         afterwardly: {
             next (value, multiple) {


### PR DESCRIPTION
The issue I was having was when trying to use `assertly-sinon` with this. I had to execute `Assert.setup()` prior to registering the addon. This wasn't documented so instead added checks to automatically execute `setup` prior to registering an addon so the defaults are there. If the addon were to add modifiers, `Assert.registry` would be there and therefor `setup` wasn't going to get executed in the `constructor`.

I think having the defaults already setup prior to registering any addons would be beneficial.